### PR TITLE
tvOS Target

### DIFF
--- a/JSONParsing.xcodeproj/project.pbxproj
+++ b/JSONParsing.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		02A66A3B1C6CD82E00387AA1 /* JSONParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A66A3A1C6CD82E00387AA1 /* JSONParsingTests.swift */; };
 		02A66A4D1C6CD95100387AA1 /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A66A4B1C6CD95100387AA1 /* JSON.swift */; };
 		02A66A4E1C6CD95100387AA1 /* JSONParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A66A4C1C6CD95100387AA1 /* JSONParsing.swift */; };
+		FCE5DA871CA975D6002AB4ED /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A66A4B1C6CD95100387AA1 /* JSON.swift */; };
+		FCE5DA881CA975D9002AB4ED /* JSONParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A66A4C1C6CD95100387AA1 /* JSONParsing.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -33,6 +35,7 @@
 		02A66A3C1C6CD82E00387AA1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		02A66A4B1C6CD95100387AA1 /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
 		02A66A4C1C6CD95100387AA1 /* JSONParsing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONParsing.swift; sourceTree = "<group>"; };
+		FCE5DA7F1CA97558002AB4ED /* JSONParsing.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = JSONParsing.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -48,6 +51,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				02A66A361C6CD82E00387AA1 /* JSONParsing.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FCE5DA7B1CA97558002AB4ED /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -68,6 +78,7 @@
 			children = (
 				02A66A2B1C6CD82E00387AA1 /* JSONParsing.framework */,
 				02A66A351C6CD82E00387AA1 /* JSONParsingTests.xctest */,
+				FCE5DA7F1CA97558002AB4ED /* JSONParsing.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -103,12 +114,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FCE5DA7C1CA97558002AB4ED /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		02A66A2A1C6CD82E00387AA1 /* JSONParsing */ = {
+		02A66A2A1C6CD82E00387AA1 /* JSONParsing-iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 02A66A3F1C6CD82E00387AA1 /* Build configuration list for PBXNativeTarget "JSONParsing" */;
+			buildConfigurationList = 02A66A3F1C6CD82E00387AA1 /* Build configuration list for PBXNativeTarget "JSONParsing-iOS" */;
 			buildPhases = (
 				02A66A261C6CD82E00387AA1 /* Sources */,
 				02A66A271C6CD82E00387AA1 /* Frameworks */,
@@ -119,7 +137,7 @@
 			);
 			dependencies = (
 			);
-			name = JSONParsing;
+			name = "JSONParsing-iOS";
 			productName = JSONParsing;
 			productReference = 02A66A2B1C6CD82E00387AA1 /* JSONParsing.framework */;
 			productType = "com.apple.product-type.framework";
@@ -142,6 +160,24 @@
 			productReference = 02A66A351C6CD82E00387AA1 /* JSONParsingTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		FCE5DA7E1CA97558002AB4ED /* JSONParsing-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FCE5DA841CA97559002AB4ED /* Build configuration list for PBXNativeTarget "JSONParsing-tvOS" */;
+			buildPhases = (
+				FCE5DA7A1CA97558002AB4ED /* Sources */,
+				FCE5DA7B1CA97558002AB4ED /* Frameworks */,
+				FCE5DA7C1CA97558002AB4ED /* Headers */,
+				FCE5DA7D1CA97558002AB4ED /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "JSONParsing-tvOS";
+			productName = "JSONParsing-tvOS";
+			productReference = FCE5DA7F1CA97558002AB4ED /* JSONParsing.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -158,6 +194,9 @@
 					02A66A341C6CD82E00387AA1 = {
 						CreatedOnToolsVersion = 7.2.1;
 					};
+					FCE5DA7E1CA97558002AB4ED = {
+						CreatedOnToolsVersion = 7.3;
+					};
 				};
 			};
 			buildConfigurationList = 02A66A251C6CD82E00387AA1 /* Build configuration list for PBXProject "JSONParsing" */;
@@ -172,8 +211,9 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				02A66A2A1C6CD82E00387AA1 /* JSONParsing */,
+				02A66A2A1C6CD82E00387AA1 /* JSONParsing-iOS */,
 				02A66A341C6CD82E00387AA1 /* JSONParsingTests */,
+				FCE5DA7E1CA97558002AB4ED /* JSONParsing-tvOS */,
 			);
 		};
 /* End PBXProject section */
@@ -187,6 +227,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		02A66A331C6CD82E00387AA1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FCE5DA7D1CA97558002AB4ED /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -213,12 +260,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		FCE5DA7A1CA97558002AB4ED /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FCE5DA881CA975D9002AB4ED /* JSONParsing.swift in Sources */,
+				FCE5DA871CA975D6002AB4ED /* JSON.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
 		02A66A381C6CD82E00387AA1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 02A66A2A1C6CD82E00387AA1 /* JSONParsing */;
+			target = 02A66A2A1C6CD82E00387AA1 /* JSONParsing-iOS */;
 			targetProxy = 02A66A371C6CD82E00387AA1 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -326,7 +382,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.fueled.JSONParsing;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -345,7 +401,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.fueled.JSONParsing;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -370,6 +426,48 @@
 			};
 			name = Release;
 		};
+		FCE5DA851CA97559002AB4ED /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = JSONParsing/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.fueled.JSONParsing;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		FCE5DA861CA97559002AB4ED /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = JSONParsing/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.fueled.JSONParsing;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -382,7 +480,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		02A66A3F1C6CD82E00387AA1 /* Build configuration list for PBXNativeTarget "JSONParsing" */ = {
+		02A66A3F1C6CD82E00387AA1 /* Build configuration list for PBXNativeTarget "JSONParsing-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				02A66A401C6CD82E00387AA1 /* Debug */,
@@ -396,6 +494,15 @@
 			buildConfigurations = (
 				02A66A431C6CD82E00387AA1 /* Debug */,
 				02A66A441C6CD82E00387AA1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FCE5DA841CA97559002AB4ED /* Build configuration list for PBXNativeTarget "JSONParsing-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FCE5DA851CA97559002AB4ED /* Debug */,
+				FCE5DA861CA97559002AB4ED /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/JSONParsing.xcodeproj/xcshareddata/xcschemes/JSONParsing-iOS.xcscheme
+++ b/JSONParsing.xcodeproj/xcshareddata/xcschemes/JSONParsing-iOS.xcscheme
@@ -16,7 +16,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "02A66A2A1C6CD82E00387AA1"
                BuildableName = "JSONParsing.framework"
-               BlueprintName = "JSONParsing"
+               BlueprintName = "JSONParsing-iOS"
                ReferencedContainer = "container:JSONParsing.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -44,7 +44,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "02A66A2A1C6CD82E00387AA1"
             BuildableName = "JSONParsing.framework"
-            BlueprintName = "JSONParsing"
+            BlueprintName = "JSONParsing-iOS"
             ReferencedContainer = "container:JSONParsing.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -66,7 +66,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "02A66A2A1C6CD82E00387AA1"
             BuildableName = "JSONParsing.framework"
-            BlueprintName = "JSONParsing"
+            BlueprintName = "JSONParsing-iOS"
             ReferencedContainer = "container:JSONParsing.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -84,7 +84,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "02A66A2A1C6CD82E00387AA1"
             BuildableName = "JSONParsing.framework"
-            BlueprintName = "JSONParsing"
+            BlueprintName = "JSONParsing-iOS"
             ReferencedContainer = "container:JSONParsing.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/JSONParsing/JSONParsing.swift
+++ b/JSONParsing/JSONParsing.swift
@@ -45,7 +45,7 @@ extension Double: JSONParsingPrimitive {}
 // JSONParsingRawString types are enums with JSONParsing-conforming RawType-s
 
 public protocol JSONParsingRawRepresentable: RawRepresentable, JSONParsing {
-	typealias RawValue: JSONParsing
+	associatedtype RawValue: JSONParsing
 }
 
 public extension JSONParsingRawRepresentable {


### PR DESCRIPTION
These changes add a **tvOS** target, so that JSONParsing can be used on tvOS.

I had to differentiate the two targets, iOS and tvOS, by adding a suffix for each of them (`JSONParsing-iOS`, `JSONParsing-tvOS`). The product name is now matching the _project name_ (and not the target name anymore).

Also made JSONParsing compliant with latest Swift syntax (`typealias` -> `associatedType`).
